### PR TITLE
fix: ignore owner restriction for Leave Application if HR manager

### DIFF
--- a/erplite/public/js/leave_application.js
+++ b/erplite/public/js/leave_application.js
@@ -2,7 +2,7 @@ frappe.ui.form.on("Leave Application", {
   refresh: function(frm) {
     if (!frm.is_new()){
       // check approvers
-      if ((frm.doc.status=='Open' && frappe.session.user!=frm.doc.leave_approver) || frappe.session.user == frm.doc.owner){
+      if ((frm.doc.status=='Open' && frappe.session.user!=frm.doc.leave_approver) || (!frappe.user.has_role('HR Manager') && frappe.session.user == frm.doc.owner)){
         $('.primary-action').hide();
         frm.set_df_property('status', 'read_only', 1);
         frm.set_df_property('leave_approver', 'read_only', 1);


### PR DESCRIPTION
## Issue description
HR Manager not able to create and submit leave applications for employees because the primary actions is hidden

## Solution description
The condition was only checking if the current user is the owner of the current leave application, added a condition to bypass this if the user has HR Manager role

## Changes Implemented
- Leave Application

## Testing done
- Mozilla Firefox